### PR TITLE
[release] Add build 250217paj0uvm5n (v6.26.1)

### DIFF
--- a/desktop-builds.json
+++ b/desktop-builds.json
@@ -1,1 +1,8 @@
-[]
+[
+  {
+    "id": "250217paj0uvm5n",
+    "version": "6.26.1",
+    "createdAt": "2025-02-17T16:11:20.404Z",
+    "isReleased": true
+  }
+]

--- a/desktop-releases.json
+++ b/desktop-releases.json
@@ -1,0 +1,4 @@
+{
+  "latestReleaseBuildId": "250217paj0uvm5n",
+  "releaseRedirections": []
+}


### PR DESCRIPTION
| Category | Details |
|----------|---------|
| App version | 6.26.1 |
| Electron version | 33.3.2 |
| Commit hash | [3387ff4a](https://github.com/ToDesktop/todesktop-builder/commit/3387ff4ad469378cb30ee713a0a0e1e5d978fedf) |
| Build Started At | Mon, 17 Feb 2025 15:50:32 GMT |
| Build Ended At | Mon, 17 Feb 2025 16:02:13 GMT |

### Files

You can find the files in the staging bucket under the prefix: `250217paj0uvm5n/`

| File | Size | MD5 | Uploaded |
|------|------|-----|----------|
| ToDesktop Builder Staging 6.26.1 - Build 250217paj0uvm5n-arm64-mac.zip.blockmap | 116,485 bytes | y03+uYESSAayuooZna7d5g== | Mon, 17 Feb 2025 16:11:18 GMT |
| ToDesktop Builder Staging 6.26.1 - Build 250217paj0uvm5n-arm64-mac.zip | 104.9MB | MvzU+R7tD8hymPuxrSJWlg== | Mon, 17 Feb 2025 16:11:17 GMT |
| ToDesktop Builder Staging 6.26.1 - Build 250217paj0uvm5n-arm64.dmg.blockmap | 119,014 bytes | j5vP1R1ulnhwoBibmpoJsw== | Mon, 17 Feb 2025 16:11:12 GMT |
| ToDesktop Builder Staging 6.26.1 - Build 250217paj0uvm5n-arm64.dmg | 108.7MB | 43epozI8xr2MCJpggw1eCQ== | Mon, 17 Feb 2025 16:11:11 GMT |
| ToDesktop Builder Staging Mac Installer (250217paj0uvm5n).zip | 1.5MB | qR/ki/hH9K1xCHAh7FaVnw== | Mon, 17 Feb 2025 16:11:18 GMT |
| ToDesktop Builder Staging Setup 6.26.1 - Build 250217paj0uvm5n-x64.exe.blockmap | 95,610 bytes | Rpw1GbFGfLNzD5Sv4+h4fg== | Mon, 17 Feb 2025 16:11:03 GMT |
| ToDesktop Builder Staging Setup 6.26.1 - Build 250217paj0uvm5n-x64.exe | 87.0MB | WmmR6GcNrnwUueYWlmXPBA== | Mon, 17 Feb 2025 16:11:03 GMT |
| latest-build-250217paj0uvm5n.yml | 437 bytes | Lql2QKoF+r2eNBawQYm3mA== | Mon, 17 Feb 2025 16:10:58 GMT |
| latest-mac-build-250217paj0uvm5n.yml | 635 bytes | HKrgsWr+oy0sIWtpJl0/Kg== | Mon, 17 Feb 2025 16:11:04 GMT |
| td-latest-build-250217paj0uvm5n.json | 407 bytes | 2k4I8fDOVMucFateJFZ/Cg== | Mon, 17 Feb 2025 16:10:57 GMT |
| td-latest-mac-build-250217paj0uvm5n.json | 862 bytes | pDd2iznfUVlc73d9Z5zzow== | Mon, 17 Feb 2025 16:11:04 GMT |
  
This PR adds a new build (ID = `250217paj0uvm5n`, version = `6.26.1`) to desktop-builds.json and releases it in desktop-releases.json.
  
Please review the changes. Once approved and merged, the staging bucket files with the `250217paj0uvm5n` prefix will be promoted to production.